### PR TITLE
145-Bug-Internal-login-infinite-loop-for-loading

### DIFF
--- a/lib/base/networking/api/handler/auth_handler.dart
+++ b/lib/base/networking/api/handler/auth_handler.dart
@@ -36,7 +36,9 @@ class AuthHandler {
         validateStatus: (status) {
           return status! < 500;
         },
+          receiveTimeout: const Duration(seconds: 5),
       ),
+
     );
     dio.interceptors.add(CookieManager(cookieJar));
 


### PR DESCRIPTION
Issue: Entering false login details takes a longer time. 
I added a timeout.

A new task/issue should be created for better error handling. e.g., if the login details are wrong, it should show that the username/password is incorrect. 