### PR TITLE
GIve an option for different camera views

### DIFF
--- a/lib/views/video_view/utils/custom_video_control_bar.dart
+++ b/lib/views/video_view/utils/custom_video_control_bar.dart
@@ -5,7 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class CustomVideoControlBar extends StatelessWidget {
   final VoidCallback onToggleChat;
-  final VoidCallback onDownload;
+  final Function(String) onDownload;
   final VoidCallback onOpenQuizzes;
   final Stream currentStream;
   final bool isChatVisible;
@@ -24,6 +24,43 @@ class CustomVideoControlBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     ThemeData themeData = Theme.of(context);
+    void showDownloadOptions() {
+      showModalBottomSheet(
+        context: context,
+        builder: (BuildContext context) {
+          return SafeArea(
+            child: Wrap(
+              children: <Widget>[
+                ListTile(
+                  leading: const Icon(Icons.download),
+                  title: const Text('Combined'),
+                  onTap: () {
+                    Navigator.pop(context);
+                    onDownload('Combined');
+                  },
+                ),
+                ListTile(
+                  leading: const Icon(Icons.present_to_all),
+                  title: const Text('Presentation Only'),
+                  onTap: () {
+                    Navigator.pop(context);
+                    onDownload('Presentation');
+                  },
+                ),
+                ListTile(
+                  leading: const Icon(Icons.videocam),
+                  title: const Text('Camera'),
+                  onTap: () {
+                    Navigator.pop(context);
+                    onDownload('Camera Only');
+                  },
+                ),
+              ],
+            ),
+          );
+        },
+      );
+    }
 
     List<Map<String, IconData>> getMenuItems(bool isPinned, bool isDownloaded) {
       List<Map<String, IconData>> items = [
@@ -77,7 +114,7 @@ class CustomVideoControlBar extends StatelessWidget {
                             .read(userViewModelProvider.notifier)
                             .pinCourse(currentStream.courseID);
                   } else if (choice == 'Download') {
-                    onDownload();
+                    showDownloadOptions();
                   }
                 },
                 itemBuilder: (BuildContext context) {

--- a/lib/views/video_view/utils/custom_video_control_bar.dart
+++ b/lib/views/video_view/utils/custom_video_control_bar.dart
@@ -21,46 +21,47 @@ class CustomVideoControlBar extends StatelessWidget {
     required this.onDownload,
   });
 
+  void _showDownloadOptions(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (BuildContext context) {
+        return SafeArea(
+          child: Wrap(
+            children: <Widget>[
+              ListTile(
+                leading: const Icon(Icons.download),
+                title: const Text('Combined'),
+                onTap: () {
+                  Navigator.pop(context);
+                  onDownload('Combined');
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.present_to_all),
+                title: const Text('Presentation Only'),
+                onTap: () {
+                  Navigator.pop(context);
+                  onDownload('Presentation');
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.videocam),
+                title: const Text('Camera'),
+                onTap: () {
+                  Navigator.pop(context);
+                  onDownload('Camera Only');
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     ThemeData themeData = Theme.of(context);
-    void showDownloadOptions() {
-      showModalBottomSheet(
-        context: context,
-        builder: (BuildContext context) {
-          return SafeArea(
-            child: Wrap(
-              children: <Widget>[
-                ListTile(
-                  leading: const Icon(Icons.download),
-                  title: const Text('Combined'),
-                  onTap: () {
-                    Navigator.pop(context);
-                    onDownload('Combined');
-                  },
-                ),
-                ListTile(
-                  leading: const Icon(Icons.present_to_all),
-                  title: const Text('Presentation Only'),
-                  onTap: () {
-                    Navigator.pop(context);
-                    onDownload('Presentation');
-                  },
-                ),
-                ListTile(
-                  leading: const Icon(Icons.videocam),
-                  title: const Text('Camera'),
-                  onTap: () {
-                    Navigator.pop(context);
-                    onDownload('Camera Only');
-                  },
-                ),
-              ],
-            ),
-          );
-        },
-      );
-    }
 
     List<Map<String, IconData>> getMenuItems(bool isPinned, bool isDownloaded) {
       List<Map<String, IconData>> items = [
@@ -114,7 +115,7 @@ class CustomVideoControlBar extends StatelessWidget {
                             .read(userViewModelProvider.notifier)
                             .pinCourse(currentStream.courseID);
                   } else if (choice == 'Download') {
-                    showDownloadOptions();
+                    _showDownloadOptions(context);
                   }
                 },
                 itemBuilder: (BuildContext context) {

--- a/lib/views/video_view/video_player.dart
+++ b/lib/views/video_view/video_player.dart
@@ -249,7 +249,7 @@ class VideoPlayerPageState extends ConsumerState<VideoPlayerPage> {
     // Check if the Combined URL is found
     if (downloadUrl == null) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Downloads not allowed for this lecture')),
+        SnackBar(content: Text('Download type "$type" not available for this lecture')),
       );
       return;
     }

--- a/lib/views/video_view/video_player.dart
+++ b/lib/views/video_view/video_player.dart
@@ -41,7 +41,7 @@ class VideoPlayerPageState extends ConsumerState<VideoPlayerPage> {
           currentStream: widget.stream,
           isChatVisible: _isChatVisible,
           isChatActive: _isChatActive,
-          onDownload: () => _downloadVideo(widget.stream),
+          onDownload: (type) => _downloadVideo(widget.stream,type),
         ),
         Expanded(
             child:
@@ -236,20 +236,20 @@ class VideoPlayerPageState extends ConsumerState<VideoPlayerPage> {
     });
   }
 
-  void _downloadVideo(Stream stream) {
+  void _downloadVideo(Stream stream,String type) {
     // Extract the "Combined" download URL from the Stream object
-    String? combinedDownloadUrl;
+    String? downloadUrl;
     for (var download in stream.downloads) {
-      if (download.friendlyName == "Combined") {
-        combinedDownloadUrl = download.downloadURL;
+      if (download.friendlyName == type) {
+     downloadUrl = download.downloadURL;
         break;
       }
     }
     //combinedDownloadUrl="https://file-examples.com/storage/fe5048eb7365a64ba96daa9/2017/04/file_example_MP4_480_1_5MG.mp4";
     // Check if the Combined URL is found
-    if (combinedDownloadUrl == null) {
+    if (downloadUrl == null) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Combined download URL not found')),
+        const SnackBar(content: Text('Downloads not allowed for this lecture')),
       );
       return;
     }
@@ -262,7 +262,7 @@ class VideoPlayerPageState extends ConsumerState<VideoPlayerPage> {
     // Call the download function from the StreamViewModel
     ref
         .read(downloadViewModelProvider.notifier)
-        .downloadVideo(combinedDownloadUrl, stream.id, fileName)
+        .downloadVideo(downloadUrl, stream.id, fileName)
         .then((localPath) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Video Downloaded')),


### PR DESCRIPTION
As there are 3 options for video. When you click on download a sheet view on bottom will open to choose from. 
e.g.
![simulator_screenshot_4061A894-9035-41F2-8B07-344BA49395E2](https://github.com/TUM-Dev/gocast_mobile/assets/123313052/e4c51ac9-16c4-4d24-b9ab-81be7a5d9af0)
